### PR TITLE
Validate keras.optimzers.schedules.CosineDecay arg

### DIFF
--- a/keras/optimizers/schedules/learning_rate_schedule.py
+++ b/keras/optimizers/schedules/learning_rate_schedule.py
@@ -648,6 +648,9 @@ class CosineDecay(LearningRateSchedule):
                 self.initial_learning_rate, name="initial_learning_rate"
             )
             dtype = initial_learning_rate.dtype
+            #validating decay_steps value
+            if not isinstance(decay_steps,int) or decay_steps<=0:
+                raise ValueError('decay_steps should be a nonzero positive integer')
             decay_steps = tf.cast(self.decay_steps, dtype)
 
             global_step_recomp = tf.cast(step, dtype)


### PR DESCRIPTION
At present decay_steps argument for keras.optimzers.schedules.CosineDecay() not validating its value.Even if users passes Zero or Negative number it is not throwing error making the training happen without updating parameters.Hence proposed changes in code to validate arguments and raise suitable error if not valid argument.